### PR TITLE
add setsockopt to set time out during reading and sending data

### DIFF
--- a/src/webserve_kq/SocketConnect.cpp
+++ b/src/webserve_kq/SocketConnect.cpp
@@ -14,6 +14,10 @@ SocketConnect::SocketConnect(int socket, int kq, std::vector<Server> *servers): 
 		throw ERR_SocketConnect("accept new request failed");
 	}
 	_clientSockaddrLen = sizeof(_clientSockaddr);
+	_timeout.tv_sec = 10; // set 10 second to max waiting time for data transfer 
+	_timeout.tv_usec = 0;
+	if (setsockopt(_numSocket, SOL_SOCKET, SO_RCVTIMEO, (const char*)&_timeout, sizeof(_timeout)) < 0)
+		throw ERR_SocketConnect("setsockopt for timeout failed");
 	if (fcntl(_numSocket, F_SETFL, O_NONBLOCK) < 0)
 		throw ERR_SocketConnect("fcntl failed");
 	EV_SET(&_clientKevent, _numSocket, EVFILT_READ, EV_ENABLE | EV_ADD, 0, 0, this);
@@ -40,6 +44,7 @@ SocketConnect& SocketConnect::operator=(const SocketConnect &source)
 		_errorNum = source._errorNum;
 		_redirectURL = source._redirectURL;
 		// _errorInfo = source._errorInfo;
+		_timeout = source._timeout;
 	}
 	return (*this);
 }

--- a/src/webserve_kq/SocketListen.cpp
+++ b/src/webserve_kq/SocketListen.cpp
@@ -18,6 +18,9 @@ SocketListen::SocketListen(int port, int kq)
 		// if the same port is already opened by other server setting, do nothing.
 		return ;
 	}
+	int	reuseport = 1;
+	if ((setsockopt(_numSocket, SOL_SOCKET, SO_REUSEADDR, &reuseport, sizeof(reuseport))) < 0)
+		throw ERR_SocketListen("setsockopt for reuse port failed");
 	if (fcntl(_numSocket, F_SETFL, O_NONBLOCK) < 0)
 		throw ERR_SocketListen("fcntl failed on listening socket");
 	EV_SET(&_listenKevent, _numSocket, EVFILT_READ, EV_ENABLE | EV_ADD, 0, 0, NULL);


### PR DESCRIPTION
I added "setsockopt" to SocketConnect to set time-out (it gives an error if the reading and sending data takes a too long time), and to SocketListen to reset the port which is just closed and re-bonded (but I'm not sure if this setting works fine... At this moment, when we stop the Webserv and re-start immediately, the server works but the client can't connect to the server. Anyway it doesn't look a big problem so I leave it...)